### PR TITLE
Add URL loader for VisualNovelViewer

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,4 +10,30 @@ Plataforma de entretenimiento interactivo que combina ruletas, visual novels, bl
   - **pages/**: Páginas principales.
   - **routes/**: Rutas dinámicas para contenido (ruleta, blog, etc.).
   - **data/**: Archivos JSON con contenido.
-  - **utils/**: Funciones helper.
+- **utils/**: Funciones helper.
+
+## Formato de los datos de la visual novel
+
+Los componentes esperan un JSON con una estructura similar a la siguiente:
+
+```json
+{
+  "scenes": [
+    {
+      "id": "intro",
+      "image": "demo-section-scene-1.png",
+      "texts": [
+        {
+          "content": "Línea de diálogo",
+          "x": 50,
+          "y": 80,
+          "parallaxSpeed": 0.2,
+          "mouseParallaxSpeed": 0.05
+        }
+      ]
+    }
+  ]
+}
+```
+
+Cada escena referencia imágenes dentro de `public/sprites/novel/`. Las burbujas de texto usan coordenadas porcentuales (`x`, `y`) y pueden incluir valores opcionales para la paralaje.

--- a/src/components/VisualNovelDemo.jsx
+++ b/src/components/VisualNovelDemo.jsx
@@ -1,5 +1,6 @@
 import React, { useState, useEffect, useRef } from "react";
 import novelData from "../data/visualNovelData";
+import { loadNovelData } from "../utils/loadNovelData";
 
 /**
  * VisualNovelViewer
@@ -28,10 +29,27 @@ export default function VisualNovelViewer({
 }) {
   const [mode, setMode] = useState(initialMode);
   const [page, setPage] = useState(0);
+  const [novel, setNovel] = useState(
+    typeof data === "string" ? null : data
+  );
   const containerRef = useRef(null);
 
-  // Normalize scenes array
-  const scenes = Array.isArray(data.scenes) ? data.scenes : Object.values(data);
+  useEffect(() => {
+    if (typeof data === "string") {
+      loadNovelData(data)
+        .then(setNovel)
+        .catch((err) => console.error(err));
+    } else {
+      setNovel(data);
+    }
+  }, [data]);
+
+  // Normalize scenes array when data available
+  const scenes = Array.isArray(novel?.scenes)
+    ? novel.scenes
+    : novel
+    ? Object.values(novel)
+    : [];
   const currentScene = scenes[page];
 
   // Parallax: scroll + mouse
@@ -78,6 +96,10 @@ export default function VisualNovelViewer({
       node.removeEventListener("mousemove", handleMouse);
     };
   }, [mode, parallaxIntensity, mouseParallaxIntensity, enableScrollParallax, enableMouseParallax]);
+
+  if (!novel) {
+    return <div>Loading...</div>;
+  }
 
   const goNext = () => setPage(p => Math.min(p + 1, scenes.length - 1));
   const goPrev = () => setPage(p => Math.max(p - 1, 0));

--- a/src/utils/loadNovelData.js
+++ b/src/utils/loadNovelData.js
@@ -1,0 +1,7 @@
+export async function loadNovelData(url) {
+  const response = await fetch(url);
+  if (!response.ok) {
+    throw new Error(`Failed to load novel data: ${response.status}`);
+  }
+  return response.json();
+}


### PR DESCRIPTION
## Summary
- support loading visual novel data via URL
- fetch data with new `loadNovelData` helper
- document JSON format for novel scenes

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68545cd772b88333b88a5a2e59fb8de6